### PR TITLE
Add more dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,15 @@ requirements:
     - pandas
     - scipy
 
+    # upstream Polymer dependencies
+    - cdsapi
+    - cython
+    - ecmwf-api-client
+    - gdal
+    - pygrib
+    - pyhdf
+    - xarray
+
 test:
   imports:
     - acwater

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2f7744b4c34a57fb4b50d89ad9653b50c328a506c41303e691345f0afafdbc1c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ requirements:
 
   run:
     - python >=3.6
-    - numpy
-    - scipy
-    - pandas
+    - geoarray
     - netcdf4
-    - geoarray 
+    - numpy
+    - pandas
+    - scipy 
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,12 +27,12 @@ requirements:
     - netcdf4
     - numpy
     - pandas
-    - scipy 
+    - scipy
 
 test:
   imports:
     - acwater
- 
+
 about:
   home: https://gitlab.awi.de/phytooptics/acwater
   summary: ACwater Polymer implements a class to load an EnMAP object and execute atmospheric correction for water surfaces and requires EnPT for the EnMAP data processing.


### PR DESCRIPTION
@alvaradobonilla
This adds the dependencies of Polymer so that they are directly included in the acwater package on conda-forge. Actually, these dependencies should be included in a conda-forge package "polymer", however, as long as this does not exist, I think it makes sense to include them here. This simplifies the installation procedure on the EnPT side.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
